### PR TITLE
Close the thrift connection of KyuubiServer when backend engine is determined as dead by EngineAliveProbe

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1295,6 +1295,14 @@ object KyuubiConf {
       .timeConf
       .createWithDefault(Duration.ofSeconds(120).toMillis)
 
+  val ENGINE_ALIVE_CLOSE_CONNETION: ConfigEntry[Boolean] =
+    buildConf("kyuubi.session.engine.alive.closeConnection")
+      .doc("Whether to kill the thrift connection to engine when engine is marked as no-alive. " +
+        "If set to true, the connection will be killed")
+      .version("1.7.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val ENGINE_OPEN_MAX_ATTEMPTS: ConfigEntry[Int] =
     buildConf("kyuubi.session.engine.open.max.attempts")
       .doc("The number of times an open engine will retry when encountering a special error.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As described in https://github.com/apache/kyuubi/issues/4457, when the backend engine becomes unresponsive, 
the beeline will hang because `client.getOperationStatus(_remoteOpHandle)` in `ExecuteStatement #waitStatementComplete()` would never receive any response.

https://github.com/apache/kyuubi/blob/43309b86f1997b028e8fde5cb4e6449d818f4f73/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala#L101-L105

While the EngineAliveProbe can identify engine failure, it does not resolve the underlying issue of the thrift client waiting for a response, causing the beeline to remain unresponsive. The only way to resolve this state of suspension is by interrupting the thrift client thread.

https://github.com/apache/kyuubi/blob/3d65f2711faa5dc9173130557e2d33adab04b5c7/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala#L84

This pull request introduces a new logic to the EngineAliveProbe feature, whereby upon detecting an engine failure, it deliberately closes the thrift connection. This creates an exception that can then be handled by the error handling mechanism introduced in apache#646, thereby allowing for a graceful shutdown of the session handle.



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

I am very happy to add a test case but I am not aware of how to simulate a state of unresponsive. 
Otherwise, I can implement test like this:
https://github.com/apache/kyuubi/blob/43309b86f1997b028e8fde5cb4e6449d818f4f73/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala#L169

- [x] Add screenshots for manual tests if appropriate

1. Add those settings in `kyuubi-default.conf`
```
kyuubi.session.engine.alive.probe.enabled true
kyuubi.session.engine.alive.probe.interval PT10S
kyuubi.session.engine.alive.timeout PT60S
kyuubi.session.engine.alive.closeConnection true
```
2. Execute a query with beeline
```
$ beeline -u 'jdbc:hive2://<KyuubiServer>:10009/default?socketTimeout=60000;#spark.yarn.queue=shared' -n jpz3032 -p <password> -f test.sql 
```
3. Go to ResourceManager and Identify the ApplicationMaster
<img width="2091" alt="Screenshot 2023-03-08 at 12 13 31" src="https://user-images.githubusercontent.com/4378066/223610552-6a35dc6a-891a-415b-b142-a2b104da2c1f.png">

4. ssh into the host and restart the NodeManager
```
[<user>@<NodeManager> ~]$ sudo -i
[root@<NodeManager> :~]# /usr/sbin/reboot
Connection to <NodeManager>  closed by remote host.
Connection to <NodeManager>  closed.
```
5. Check the kyuubi server log: the session is terminated with error
```
2023-03-08 12:15:36.565 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:41.567 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:46.568 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
```
After 3 consecutive alive probe fails, Engine is marked dead.
```
2023-03-08 12:16:01.246 WARN org.apache.kyuubi.client.KyuubiSyncThriftClient: The engine[Some(application_1676285123186_0426)] alive probe fails
org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_GetInfo(TCLIService.java:222) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.GetInfo(TCLIService.java:209) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1(KyuubiSyncThriftClient.scala:93) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1$adapted(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.Option.foreach(Option.scala:407) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.run(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_362]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_362]
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345) ~[?:1.8.0_362]
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127) ~[libthrift-0.9.3.jar:0.9.3]
        ... 23 more
2023-03-08 12:16:21.258 WARN org.apache.kyuubi.client.KyuubiSyncThriftClient: The engine[Some(application_1676285123186_0426)] alive probe fails
org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_GetInfo(TCLIService.java:222) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.GetInfo(TCLIService.java:209) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1(KyuubiSyncThriftClient.scala:93) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1$adapted(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.Option.foreach(Option.scala:407) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.run(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_362]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_362]
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345) ~[?:1.8.0_362]
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127) ~[libthrift-0.9.3.jar:0.9.3]
        ... 23 more
2023-03-08 12:16:41.269 WARN org.apache.kyuubi.client.KyuubiSyncThriftClient: The engine[Some(application_1676285123186_0426)] alive probe fails
org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_GetInfo(TCLIService.java:222) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.GetInfo(TCLIService.java:209) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1(KyuubiSyncThriftClient.scala:93) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.$anonfun$run$1$adapted(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.Option.foreach(Option.scala:407) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient$$anon$1.run(KyuubiSyncThriftClient.scala:87) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_362]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_362]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_362]
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345) ~[?:1.8.0_362]
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127) ~[libthrift-0.9.3.jar:0.9.3]
        ... 23 more
2023-03-08 12:16:41.269 ERROR org.apache.kyuubi.client.KyuubiSyncThriftClient: Mark the engine[Some(application_1676285123186_0426)] not alive with no recent alive probe success: 60033 ms exceeds timeout 60000 ms
```
Now force closing the thrift client to generate an exception.
```
2023-03-08 12:17:21.270 WARN org.apache.kyuubi.client.KyuubiSyncThriftClient: Force closing transport to interrupt the protocol thread,
2023-03-08 12:17:21.271 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing jpz3032's query[8bcee60d-84c3-4982-af53-72a2f90419bf]: RUNNING_STATE -> ERROR_STATE, time taken: 289.881 seconds
```
OperationManager try `closeOperation` but failed because the connection is already closed 
```
2023-03-08 12:17:21.278 WARN org.apache.kyuubi.operation.ExecuteStatement: Error closing THandleIdentifier(guid:58 C3 25 C4 24 3A 4D 8C 81 D6 13 93 AA BA 45 43, secret:C2 EE 5B 97 3E A0 41 FC AC 16 9B D7 08 ED 8F 38): connection does not exist
org.apache.kyuubi.KyuubiSQLException: connection does not exist
        at org.apache.kyuubi.KyuubiSQLException$.connectionDoesNotExist(KyuubiSQLException.scala:90) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.withLockAcquired(KyuubiSyncThriftClient.scala:136) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.withLockAcquiredAsyncRequest(KyuubiSyncThriftClient.scala:142) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.closeOperation(KyuubiSyncThriftClient.scala:389) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.operation.KyuubiOperation.liftedTree3$1(KyuubiOperation.scala:136) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.operation.KyuubiOperation.close(KyuubiOperation.scala:135) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.operation.OperationManager.closeOperation(OperationManager.scala:126) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.AbstractSession.$anonfun$closeOperation$1(AbstractSession.scala:224) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.session.AbstractSession.withAcquireRelease(AbstractSession.scala:82) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.AbstractSession.closeOperation(AbstractSession.scala:222) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.AbstractBackendService.closeOperation(AbstractBackendService.scala:188) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.org$apache$kyuubi$server$BackendServiceMetric$$super$closeOperation(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.$anonfun$closeOperation$1(BackendServiceMetric.scala:169) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.metrics.MetricsSystem$.timerTracing(MetricsSystem.scala:111) ~[kyuubi-metrics_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeOperation(BackendServiceMetric.scala:169) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeOperation$(BackendServiceMetric.scala:167) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.closeOperation(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.TFrontendService.CloseOperation(TFrontendService.scala:498) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseOperation.getResult(TCLIService.java:1797) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseOperation.getResult(TCLIService.java:1782) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286) ~[libthrift-0.9.3.jar:0.9.3]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
```

AliveProbeClient try to close the remote handler but failed. 
It's expected as the backend Engine is dead already. 
```
2023-03-08 12:17:21.290 INFO org.apache.kyuubi.server.KyuubiTBinaryFrontendService: Received request of closing SessionHandle [9a91b697-3abb-4da7-9eab-3d3998f8c377]
2023-03-08 12:17:21.290 INFO org.apache.kyuubi.session.KyuubiSessionManager: jpz3032's session with SessionHandle [9a91b697-3abb-4da7-9eab-3d3998f8c377] is closed, current opening sessions 0
2023-03-08 12:17:31.292 ERROR org.apache.kyuubi.Utils: Uncaught exception in thread KyuubiTBinaryFrontendHandler-Pool: Thread-678
org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_CloseSession(TCLIService.java:199) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.CloseSession(TCLIService.java:186) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$closeSession$4(KyuubiSyncThriftClient.scala:222) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.Utils$.tryLogNonFatalError(Utils.scala:297) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$closeSession$3(KyuubiSyncThriftClient.scala:220) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$closeSession$3$adapted(KyuubiSyncThriftClient.scala:219) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.Option.foreach(Option.scala:407) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.closeSession(KyuubiSyncThriftClient.scala:219) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.KyuubiSessionImpl.close(KyuubiSessionImpl.scala:251) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.SessionManager.closeSession(SessionManager.scala:131) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.KyuubiSessionManager.closeSession(KyuubiSessionManager.scala:121) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.AbstractBackendService.closeSession(AbstractBackendService.scala:49) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.org$apache$kyuubi$server$BackendServiceMetric$$super$closeSession(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.$anonfun$closeSession$1(BackendServiceMetric.scala:43) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.metrics.MetricsSystem$.timerTracing(MetricsSystem.scala:111) ~[kyuubi-metrics_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeSession(BackendServiceMetric.scala:43) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeSession$(BackendServiceMetric.scala:41) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.closeSession(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.TFrontendService.CloseSession(TFrontendService.scala:209) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1517) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1502) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286) ~[libthrift-0.9.3.jar:0.9.3]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_362]
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_362]
        at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286) ~[?:1.8.0_362]
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345) ~[?:1.8.0_362]
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127) ~[libthrift-0.9.3.jar:0.9.3]
        ... 39 more
```
KyuubiSyncThriftClient#closeSession failed
It's expected as the backend Engine is dead already. 
```
2023-03-08 12:17:31.294 ERROR org.apache.kyuubi.server.KyuubiTBinaryFrontendService: Error closing session: 
org.apache.kyuubi.KyuubiSQLException: Error while cleaning up the engine resources
        at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.closeSession(KyuubiSyncThriftClient.scala:213) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.KyuubiSessionImpl.close(KyuubiSessionImpl.scala:251) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.SessionManager.closeSession(SessionManager.scala:131) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.session.KyuubiSessionManager.closeSession(KyuubiSessionManager.scala:121) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.AbstractBackendService.closeSession(AbstractBackendService.scala:49) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.org$apache$kyuubi$server$BackendServiceMetric$$super$closeSession(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.$anonfun$closeSession$1(BackendServiceMetric.scala:43) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.17.jar:?]
        at org.apache.kyuubi.metrics.MetricsSystem$.timerTracing(MetricsSystem.scala:111) ~[kyuubi-metrics_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeSession(BackendServiceMetric.scala:43) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.BackendServiceMetric.closeSession$(BackendServiceMetric.scala:41) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.server.KyuubiServer$$anon$1.closeSession(KyuubiServer.scala:138) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.service.TFrontendService.CloseSession(TFrontendService.scala:209) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1517) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1502) ~[hive-service-rpc-3.1.3.jar:3.1.3]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39) ~[libthrift-0.9.3.jar:0.9.3]
        at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286) ~[libthrift-0.9.3.jar:0.9.3]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: org.apache.kyuubi.KyuubiSQLException: connection does not exist
        at org.apache.kyuubi.KyuubiSQLException$.connectionDoesNotExist(KyuubiSQLException.scala:90) ~[kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.withLockAcquired(KyuubiSyncThriftClient.scala:136) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.withLockAcquiredAsyncRequest(KyuubiSyncThriftClient.scala:142) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.closeSession(KyuubiSyncThriftClient.scala:208) ~[kyuubi-server_2.12-1.7.0-SNAPSHOT.jar:1.7.0-SNAPSHOT]
        ... 21 more
2023-03-08 12:17:31.294 INFO org.apache.kyuubi.server.KyuubiTBinaryFrontendService: Finished closing SessionHandle [9a91b697-3abb-4da7-9eab-3d3998f8c377]
```
6. Beeline Logs
Beeline finished with errors (as expected)

```
2023-03-08 12:14:41.552 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:14:46.554 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:14:51.555 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:14:56.556 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:01.557 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:06.558 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:11.560 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:16.561 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:21.562 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:26.563 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:31.564 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:36.565 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:41.567 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:15:46.568 INFO org.apache.kyuubi.operation.ExecuteStatement: Query[8bcee60d-84c3-4982-af53-72a2f90419bf] in RUNNING_STATE
2023-03-08 12:17:21.271 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing jpz3032's query[8bcee60d-84c3-4982-af53-72a2f90419bf]: RUNNING_STATE -> ERROR_STATE, time taken: 289.881 seconds
Error: org.apache.kyuubi.KyuubiSQLException: Error operating ExecuteStatement: org.apache.thrift.transport.TTransportException: java.net.SocketException: Socket closed
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376)
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453)
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435)
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77)
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_GetOperationStatus(TCLIService.java:475)
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.GetOperationStatus(TCLIService.java:462)
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$getOperationStatus$1(KyuubiSyncThriftClient.scala:373)
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$withLockAcquiredAsyncRequest$2(KyuubiSyncThriftClient.scala:148)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.net.SocketException: Socket closed
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
        at java.net.SocketInputStream.read(SocketInputStream.java:171)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127)
        ... 20 more

        at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
        at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:76)
        at org.apache.kyuubi.operation.KyuubiOperation$$anonfun$onError$1.applyOrElse(KyuubiOperation.scala:57)
        at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)
        at org.apache.kyuubi.operation.ExecuteStatement.waitStatementComplete(ExecuteStatement.scala:144)
        at org.apache.kyuubi.operation.ExecuteStatement.$anonfun$runInternal$1(ExecuteStatement.scala:161)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.thrift.transport.TTransportException: java.net.SocketException: Socket closed
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
        at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376)
        at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453)
        at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435)
        at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37)
        at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
        at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
        at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
        at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77)
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_GetOperationStatus(TCLIService.java:475)
        at org.apache.hive.service.rpc.thrift.TCLIService$Client.GetOperationStatus(TCLIService.java:462)
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$getOperationStatus$1(KyuubiSyncThriftClient.scala:373)
        at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$withLockAcquiredAsyncRequest$2(KyuubiSyncThriftClient.scala:148)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        ... 3 more
Caused by: java.net.SocketException: Socket closed
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
        at java.net.SocketInputStream.read(SocketInputStream.java:171)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
        at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:127)
        ... 20 more (state=,code=0)
Closing: 0: jdbc:hive2://lndcndevms1510.nhnjp.ism:10009/default?socketTimeout=60000;#spark.yarn.queue=shared
```




- [ ] [Run test](https://kyuubi.readthedocs.io/en/master/develop_tools/testing.html#running-tests) locally before make a pull request

The kyuubi-server suite wasn't working even before this PR.
